### PR TITLE
Torch 1.11.0 patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN pip3 install --no-cache-dir \
     twine==1.13.0 \
     awscli==1.16.194 \
     numpy==1.16.4 \
-	cmake==3.18 \
+    cmake==3.18 \
     packaging
 
 ARG TORCH_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN pip3 install --no-cache-dir \
 
 ARG TORCH_VERSION
 # Install PyTorch
-RUN pip3 install --no-cache-dir torch==$TORCH_VERSION
+RUN pip3 install --no-cache-dir torch==$TORCH_VERSION --extra-index-url https://download.pytorch.org/whl/cu113
 
 RUN git clone https://github.com/doxygen/doxygen.git &&\
     cd doxygen &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+ENV TZ=Europe/Kiev
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update &&\
     apt-get -y install build-essential yasm nasm cmake unzip git wget \
     sysstat libtcmalloc-minimal4 pkgconf autoconf libtool flex bison \
     python3 python3-pip python3-dev python3-setuptools &&\
     ln -s /usr/bin/python3 /usr/bin/python &&\
-    ln -s /usr/bin/pip3 /usr/bin/pip &&\
     apt-get clean &&\
     apt-get autoremove &&\
     rm -rf /var/lib/apt/lists/* &&\
@@ -45,6 +46,7 @@ RUN pip3 install --no-cache-dir \
     twine==1.13.0 \
     awscli==1.16.194 \
     numpy==1.16.4 \
+	cmake==3.18 \
     packaging
 
 ARG TORCH_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME?=argus-tensor-stream
-TORCH_VERSION?=1.11.0
+TORCH_VERSION?=1.9.0
 DOCKER_NAME="$(NAME)-$(TORCH_VERSION)"
 
 GPUS?=all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME?=argus-tensor-stream
-TORCH_VERSION?=1.9.0
+TORCH_VERSION?=1.11.0
 DOCKER_NAME="$(NAME)-$(TORCH_VERSION)"
 
 GPUS?=all

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ It is convenient to use TensorStream in Docker containers. The provided [Dockerf
 #### TensorStream source code
 
 ```
-git clone -b master --single-branch https://github.com/Fonbet/argus-tensor-stream.git
-cd argus-tensor-stream
+git clone -b master --single-branch https://github.com/osai-ai/tensor-stream.git
+cd tensor-stream
 ```
 
 #### C++ extension for Python
@@ -76,9 +76,9 @@ set VS150COMNTOOLS="Path to Visual Studio vcvarsall.bat folder"
 call "%VS150COMNTOOLS%\vcvarsall.bat" x64 -vcvars_ver=14.11
 python setup.py install
 ```
-To build TensorStream on Windows, Visual Studio 2017 14.11 toolset is required
+### Building C++ library:
 
-#### C++ library:
+To build TensorStream on Windows, Visual Studio 2017 14.11 toolset is required
 
 On Linux:
 ```
@@ -108,7 +108,7 @@ pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.4.0/linux/tensor
 pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.5.0/linux/tensor_stream-0.4.0-cp36-cp36m-linux_x86_64.whl
 ```
 
-#### Building examples and tests
+### Building examples and tests
 Examples for Python and C++ can be found in [c_examples](c_examples) and [python_examples](python_examples) folders.  Tests for C++ can be found in [tests](tests) folder.
 #### Python example
 Can be executed via Python after TensorStream [C++ extension for Python](#c-extension-for-python) installation.
@@ -150,7 +150,7 @@ docker run --gpus=all -ti tensorstream bash
 
 ## Usage
 
-### Samples
+### Python examples
 
 1. Simple [example](python_examples/simple.py) demonstrates RTMP to PyTorch tensor conversion. Let's consider some usage scenarios:
 > **Note:** You can pass **--help** to get the list of all available options, their description and default values

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ while need_predictions:
 ## Install TensorStream
 
 ### Dependencies
-* [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 10.0 or above
+* [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 11.0 or above
 * [FFmpeg](https://github.com/FFmpeg/FFmpeg) and FFmpeg version of headers required to interface with Nvidias codec APIs
 [nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers)
 * [PyTorch](https://github.com/pytorch/pytorch) 1.9.0 or above to build C++ extension for Python
@@ -95,8 +95,6 @@ cmake -G "Visual Studio 15 2017 Win64" -T v141,version=14.11 ..
 ### Binaries (Linux only)
 Extension for Python can be installed via pip:
 
-- **CUDA 9:**
-> **Warning:** CUDA 9 isn't supported by TensorStream anymore so new releases won't be built and distributed in binary format.
 - **CUDA 10:**
 TensorStream compiled with different versions of Pytorch:
 ```

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.4.0/linux/tensor
 ```
 pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.5.0/linux/tensor_stream-0.4.0-cp36-cp36m-linux_x86_64.whl
 ```
-- **CUDA 11:**
 
 ### Building examples and tests
 Examples for Python and C++ can be found in [c_examples](c_examples) and [python_examples](python_examples) folders.  Tests for C++ can be found in [tests](tests) folder.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ set VS150COMNTOOLS="Path to Visual Studio vcvarsall.bat folder"
 call "%VS150COMNTOOLS%\vcvarsall.bat" x64 -vcvars_ver=14.11
 python setup.py install
 ```
-### Building C++ library:
-
 To build TensorStream on Windows, Visual Studio 2017 14.11 toolset is required
+
+#### C++ library:
 
 On Linux:
 ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ On Linux:
 python setup.py install
 ```
 
-On Windows:
+On Windows (using Visual Studio 2017 14.11 toolset as example):
 ```
 set FFMPEG_PATH="Path to FFmpeg install folder"
 set path=%path%;%FFMPEG_PATH%\bin
@@ -84,7 +84,7 @@ mkdir build
 cd build
 cmake ..
 ```
-On Windows:
+On Windows (using Visual Studio 2017 14.11 toolset as example):
 ```
 set FFMPEG_PATH="Path to FFmpeg install folder"
 mkdir build
@@ -113,14 +113,14 @@ cd python_examples
 python simple.py
 ```
 #### C++ example and unit tests
-On Linux
+On Linux:
 ```
 cd c_examples  # tests
 mkdir build
 cd build
 cmake -DCMAKE_PREFIX_PATH=$PWD/../../cmake ..
 ```
-On Windows
+On Windows (using Visual Studio 2017 14.11 toolset as example):
 ```
 set FFMPEG_PATH="Path to FFmpeg install folder"
 cd c_examples or tests

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ while need_predictions:
 ## Install TensorStream
 
 ### Dependencies
-* [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 9.0 or above
+* [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 10.0 or above
 * [FFmpeg](https://github.com/FFmpeg/FFmpeg) and FFmpeg version of headers required to interface with Nvidias codec APIs
 [nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers)
-* [PyTorch](https://github.com/pytorch/pytorch) 1.1.0 or above to build C++ extension for Python
+* [PyTorch](https://github.com/pytorch/pytorch) 1.9.0 or above to build C++ extension for Python
 * [Python](https://www.python.org/) 3.6 or above to build C++ extension for Python
 
 It is convenient to use TensorStream in Docker containers. The provided [Dockerfiles](#docker-image) is supplied to create an image with all the necessary dependencies.
@@ -76,8 +76,6 @@ set VS150COMNTOOLS="Path to Visual Studio vcvarsall.bat folder"
 call "%VS150COMNTOOLS%\vcvarsall.bat" x64 -vcvars_ver=14.11
 python setup.py install
 ```
-To build TensorStream on Windows, Visual Studio 2017 14.11 toolset is required
-
 #### C++ library:
 
 On Linux:
@@ -107,6 +105,7 @@ pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.4.0/linux/tensor
 ```
 pip install https://tensorstream.argus-ai.com/wheel/cu10/torch1.5.0/linux/tensor_stream-0.4.0-cp36-cp36m-linux_x86_64.whl
 ```
+- **CUDA 11:**
 
 ### Building examples and tests
 Examples for Python and C++ can be found in [c_examples](c_examples) and [python_examples](python_examples) folders.  Tests for C++ can be found in [tests](tests) folder.
@@ -136,7 +135,7 @@ cmake -DCMAKE_PREFIX_PATH=%cd%\..\..\cmake -G "Visual Studio 15 2017 Win64" -T v
 ## Docker image
 To build TensorStream need to pass Pytorch version via TORCH_VERSION argument:
 ```
-docker build --build-arg TORCH_VERSION=1.5.0 -t tensorstream .
+docker build --build-arg TORCH_VERSION=1.9.0 -t tensorstream .
 ```
 Run with a bash command line and follow the [installation guide](#install-tensorstream)
 ```

--- a/include/Wrappers/WrapperPython.h
+++ b/include/Wrappers/WrapperPython.h
@@ -3,7 +3,7 @@
 #ifdef _DEBUG
 #undef _DEBUG
 #include <torch/extension.h>
-#include <THC/THC.h>
+//#include <THC/THC.h>
 #include <ATen/ATen.h>
 #if (__linux__)
 #include <pybind11/pybind11.h>
@@ -12,7 +12,7 @@
 #define _DEBUG
 #else
 #include <torch/extension.h>
-#include <THC/THC.h>
+//#include <THC/THC.h>
 #include <ATen/ATen.h>
 #if (__linux__)
 #include <pybind11/pybind11.h>

--- a/include/Wrappers/WrapperPython.h
+++ b/include/Wrappers/WrapperPython.h
@@ -3,7 +3,6 @@
 #ifdef _DEBUG
 #undef _DEBUG
 #include <torch/extension.h>
-//#include <THC/THC.h>
 #include <ATen/ATen.h>
 #if (__linux__)
 #include <pybind11/pybind11.h>
@@ -12,7 +11,6 @@
 #define _DEBUG
 #else
 #include <torch/extension.h>
-//#include <THC/THC.h>
 #include <ATen/ATen.h>
 #if (__linux__)
 #include <pybind11/pybind11.h>

--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG main
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Изначально возникла необходимость исправить сборку tensor-stream при установленном Pytorch 1.11.0. Чуть позже выяснилось, что данное исправление также работает и с установленным Pytorch 1.9.0. Поэтому специального определения версии Pytorch не нужно. 
Попутно при скачивании репозитория googletest изменена ветка master->main, т.к. Google переименовал ветку.