### PR TITLE
Fix cuda stream memory leak

### DIFF
--- a/src/VideoProcessor.cpp
+++ b/src/VideoProcessor.cpp
@@ -165,6 +165,11 @@ int VideoProcessor::Convert(AVFrame* input, AVFrame* output, FrameParameters& op
 
 void VideoProcessor::Close() {
 	PUSH_RANGE("VideoProcessor::Close", NVTXColors::YELLOW);
+	cudaError err;
+	for (auto stream : streamArr) {
+		err = cudaStreamDestroy(stream.second);
+		CHECK_STATUS_THROW(err);
+	}
 	if (isClosed)
 		return;
 	isClosed = true;


### PR DESCRIPTION
After using the streams, we have to destroy them