### PR TITLE
Fix decoder and parser memleaks

### DIFF
--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -49,7 +49,7 @@ void Decoder::Close() {
 	if (isClosed)
 		return;
 	av_buffer_unref(&deviceReference);
-	avcodec_close(decoderContext);
+	avcodec_free_context(&decoderContext);
 	for (auto item : framesBuffer) {
 		if (item != nullptr)
 			av_frame_free(&item);

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -140,14 +140,12 @@ int Decoder::Decode(AVPacket* pkt) {
 	}
 	AVFrame* decodedFrame = av_frame_alloc();
 	sts = avcodec_receive_frame(decoderContext, decodedFrame);
-
-	if (sts == AVERROR(EAGAIN) || sts == AVERROR_EOF) {
-		av_frame_free(&decodedFrame);
-		av_packet_unref(pkt);
-		return sts;
-	}
 	//deallocate copy(!) of packet from Reader
 	av_packet_unref(pkt);
+	if (sts == AVERROR(EAGAIN) || sts == AVERROR_EOF) {
+		av_frame_free(&decodedFrame);
+		return sts;
+	}
 	{
 		std::unique_lock<std::mutex> locker(sync);
 		if (framesBuffer[(currentFrame) % state.bufferDeep]) {

--- a/src/Decoder.cpp
+++ b/src/Decoder.cpp
@@ -135,6 +135,7 @@ int Decoder::Decode(AVPacket* pkt) {
 	int sts = VREADER_OK;
 	sts = avcodec_send_packet(decoderContext, pkt);
 	if (sts < 0 || sts == AVERROR(EAGAIN) || sts == AVERROR_EOF) {
+		av_packet_unref(pkt);
 		return sts;
 	}
 	AVFrame* decodedFrame = av_frame_alloc();
@@ -142,6 +143,7 @@ int Decoder::Decode(AVPacket* pkt) {
 
 	if (sts == AVERROR(EAGAIN) || sts == AVERROR_EOF) {
 		av_frame_free(&decodedFrame);
+		av_packet_unref(pkt);
 		return sts;
 	}
 	//deallocate copy(!) of packet from Reader

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -305,16 +305,15 @@ int Parser::Init(ParserParameters& input, std::shared_ptr<Logger> logger) {
 	int sts = VREADER_OK;
 	this->logger = logger;
 	//packet_buffer - isn't empty
-	AVDictionary *opts = 0;
-	av_dict_set(&opts, "rtsp_transport", "tcp", 0);
 	formatContext = avformat_alloc_context();
+	av_dict_set(&formatContext->metadata, "rtsp_transport", "tcp", 0);
 	if (input.keepBuffer == false)
 		formatContext->flags = AVFMT_FLAG_NOBUFFER;
 	const AVIOInterruptCB intCallback = { interruptCallback, formatContext };
 	formatContext->interrupt_callback = intCallback;
 	latestFrameTimestamp = std::chrono::system_clock::now();
 	formatContext->opaque = &latestFrameTimestamp;
-	sts = avformat_open_input(&formatContext, state.inputFile.c_str(), 0, &opts);
+	sts = avformat_open_input(&formatContext, state.inputFile.c_str(), 0, &formatContext->metadata);
 	CHECK_STATUS(sts);
 	sts = avformat_find_stream_info(formatContext, 0);
 	CHECK_STATUS(sts);

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -305,15 +305,17 @@ int Parser::Init(ParserParameters& input, std::shared_ptr<Logger> logger) {
 	int sts = VREADER_OK;
 	this->logger = logger;
 	//packet_buffer - isn't empty
+	AVDictionary *opts = 0;
+	av_dict_set(&opts, "rtsp_transport", "tcp", 0);
 	formatContext = avformat_alloc_context();
-	av_dict_set(&formatContext->metadata, "rtsp_transport", "tcp", 0);
 	if (input.keepBuffer == false)
 		formatContext->flags = AVFMT_FLAG_NOBUFFER;
 	const AVIOInterruptCB intCallback = { interruptCallback, formatContext };
 	formatContext->interrupt_callback = intCallback;
 	latestFrameTimestamp = std::chrono::system_clock::now();
 	formatContext->opaque = &latestFrameTimestamp;
-	sts = avformat_open_input(&formatContext, state.inputFile.c_str(), 0, &formatContext->metadata);
+	sts = avformat_open_input(&formatContext, state.inputFile.c_str(), 0, &opts);
+	av_dict_free(&opts);
 	CHECK_STATUS(sts);
 	sts = avformat_find_stream_info(formatContext, 0);
 	CHECK_STATUS(sts);


### PR DESCRIPTION
Fixed two potential memory leaks:
1) Decoder:
Fix free `decoderContext`,  `AVCodecContext` should be freed with `avcodec_free_context()` not `avcodec_close()`. [Docs](http://ffmpeg.org/doxygen/trunk/group__lavc__core.html#gae80afec6f26df6607eaacf39b561c315) about `avcodec_alloc_context3`.
2) Parser:
Fix memleak ralated with incorrect memory allocation in `avformat_open_input` func.

I attach some logs from valgrind:

1) Parser memleak:

```
==9512== Memcheck, a memory error detector
==9512== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==9512== Using Valgrind-3.13.0 and LibVEX; rerun with -h for copyright info
==9512== Command: ./sample
==9512== Parent PID: 17
==9512== 
==9512== 
==9512== HEAP SUMMARY:
==9512==     in use at exit: 5,100 bytes in 400 blocks
==9512==   total heap usage: 201,136 allocs, 200,736 frees, 1,856,204,892 bytes allocated
==9512== 
==9512== 5,100 (1,600 direct, 3,500 indirect) bytes in 100 blocks are definitely lost in loss record 4 of 4
==9512==    at 0x4C33E76: memalign (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9512==    by 0x4C33F91: posix_memalign (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9512==    by 0x6B87B82: av_malloc (in /usr/local/lib/libavutil.so.56.31.100)
==9512==    by 0x6B87D88: av_mallocz (in /usr/local/lib/libavutil.so.56.31.100)
==9512==    by 0x6B75B08: av_dict_set (in /usr/local/lib/libavutil.so.56.31.100)
==9512==    by 0x6B8C10B: av_opt_set_dict2 (in /usr/local/lib/libavutil.so.56.31.100)
==9512==    by 0x700CFDA: avformat_open_input (in /usr/local/lib/libavformat.so.58.29.100)
==9512==    by 0x11FE28: Parser::Init(ParserParameters&, std::shared_ptr<Logger>) (in /home/proj/sample)
==9512==    by 0x112AD9: main (in /home/proj/sample)
==9512== 
==9512== LEAK SUMMARY:
==9512==    definitely lost: 1,600 bytes in 100 blocks
==9512==    indirectly lost: 3,500 bytes in 300 blocks
==9512==      possibly lost: 0 bytes in 0 blocks
==9512==    still reachable: 0 bytes in 0 blocks
==9512==         suppressed: 0 bytes in 0 blocks
==9512== 
==9512== For counts of detected and suppressed errors, rerun with: -v
==9512== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

2. Decoder memleak:
```
...
==11055== 115,500 (105,600 direct, 9,900 indirect) bytes in 100 blocks are definitely lost in loss record 1,220 of 1,236
==11055==    at 0x4C33E76: memalign (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11055==    by 0x4C33F91: posix_memalign (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==11055==    by 0x6B87B82: av_malloc (in /usr/local/lib/libavutil.so.56.31.100)
==11055==    by 0x59EDE42: avcodec_alloc_context3 (in /usr/local/lib/libavcodec.so.58.54.100)
==11055==    by 0x1194B1: Decoder::Init(DecoderParameters&, std::shared_ptr<Logger>) (in /home/proj/sample)
==11055==    by 0x112B84: main (in /home/proj/sample)
==11055== 
==11055== LEAK SUMMARY:
==11055==    definitely lost: 107,200 bytes in 200 blocks
==11055==    indirectly lost: 13,400 bytes in 400 blocks
==11055==      possibly lost: 19,624 bytes in 168 blocks
==11055==    still reachable: 9,211,914 bytes in 8,558 blocks
==11055==         suppressed: 0 bytes in 0 blocks
==11055== Reachable blocks (those to which a pointer was found) are not shown.
==11055== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11055== 
==11055== For counts of detected and suppressed errors, rerun with: -v
==11055== ERROR SUMMARY: 113 errors from 113 contexts (suppressed: 0 from 0)
```

After my fixes:
```
...
==11861== LEAK SUMMARY:
==11861==    definitely lost: 0 bytes in 0 blocks
==11861==    indirectly lost: 0 bytes in 0 blocks
==11861==      possibly lost: 19,624 bytes in 168 blocks
==11861==    still reachable: 9,211,930 bytes in 8,558 blocks
==11861==         suppressed: 0 bytes in 0 blocks
==11861== Reachable blocks (those to which a pointer was found) are not shown.
==11861== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==11861== 
==11861== For counts of detected and suppressed errors, rerun with: -v
==11861== ERROR SUMMARY: 111 errors from 111 contexts (suppressed: 0 from 0)
```

Also attach the code to reproduce the problem:
1) Parser test:
```c
#include "Parser.h"

int main() {
  for (int i = 0; i < 100; i++) {
    Parser parser;
    ParserParameters parserArgs = {
        "rtmp://37.228.119.44:1935/vod/big_buck_bunny.mp4"};
    parser.Init(parserArgs, std::make_shared<Logger>());

    parser.Close();
  }
  return 0;
}
```

2) Decoder test:
```c
#include "Parser.h"
#include "Decoder.h"

int main() {
  for (int i = 0; i < 100; i++) {
    std::shared_ptr<Parser> parser = std::make_shared<Parser>();
    ParserParameters parserArgs = {
        "rtmp://37.228.119.44:1935/vod/big_buck_bunny.mp4"};
    parser->Init(parserArgs, std::make_shared<Logger>());
    
    Decoder decoder;
    DecoderParameters decoderArgs = { parser, false };
    decoder.Init(decoderArgs, std::make_shared<Logger>());

    parser->Close();
    decoder.Close();
  }
  return 0;
}
```

Thanks!