### PR TITLE
backward compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 project(TensorStream LANGUAGES CXX CUDA)
 
 function(strip_quotes_slash name)

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN pip3 install --no-cache-dir \
     twine==1.13.0 \
     awscli==1.16.194 \
     numpy==1.16.4 \
-    cmake==3.18 \
     packaging
 
 ARG TORCH_VERSION

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ while need_predictions:
 * [NVIDIA CUDA](https://developer.nvidia.com/cuda-downloads) 11.0 or above
 * [FFmpeg](https://github.com/FFmpeg/FFmpeg) and FFmpeg version of headers required to interface with Nvidias codec APIs
 [nv-codec-headers](https://github.com/FFmpeg/nv-codec-headers)
-* [PyTorch](https://github.com/pytorch/pytorch) 1.9.0 or above to build C++ extension for Python
+* [PyTorch](https://github.com/pytorch/pytorch) 1.4.0 or above to build C++ extension for Python
 * [Python](https://www.python.org/) 3.6 or above to build C++ extension for Python
 
 It is convenient to use TensorStream in Docker containers. The provided [Dockerfiles](#docker-image) is supplied to create an image with all the necessary dependencies.


### PR DESCRIPTION
Я когда делал поддержку PyTorch 1.11 и CUDA 11.3, немного погорячился, и указал в описании, что минимальная поддерживаемая версия PyTorch - 1.9 (т.к. эта версия была установлена по-умолчанию в Makefile). После мержа того PR кто-то из наших просил проверить поддержку PyTorch 1.4. Проверил, все хорошо собирается и проходят все тесты даже с PyTorch 1.4. Поэтому в документации возвращаю обратную совместимость с PyTorch 1.4, а в Makefile оставляю по-умолчанию 1.9.
То же с cmake. В CMakeLists.txt была указана мин. версия 3.18. Но это потребовало дополнительную установку cmake в Dockerfile через pip, т.к. apt-get не поддерживает cmake 3.18. Проверил сборку и тесты при указании в CMakeLists.txt мин. версии 3.16. Все хорошо, и это дает возможность убрать лишнюю установку, чтобы поддерживался cmake 3.16 из базового имэджа.
Для dev в общем-то это все не важно, просто хочу сделать, чтобы предстоящий релиз dev->master получился более плавным.